### PR TITLE
Add compatibility with QT6

### DIFF
--- a/src/YM2608-Tone-Editor.pro
+++ b/src/YM2608-Tone-Editor.pro
@@ -7,6 +7,7 @@
 QT       = core gui multimedia
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
 
 TARGET = YM2608ToneEditor
 TEMPLATE = app

--- a/src/audio_stream.hpp
+++ b/src/audio_stream.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QAudioSink>
+#else
 #include <QAudioOutput>
+#endif
 #include <QAudioFormat>
 #include <memory>
 #include "chips/chip_def.h"
@@ -20,7 +25,11 @@ public:
 private:
     chip::Chip& chip_;
     QAudioFormat format_;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    std::unique_ptr<QAudioSink> audio_;
+#else
     std::unique_ptr<QAudioOutput> audio_;
+#endif
     std::unique_ptr<AudioStreamMixier> mixer_;
 
     void start();

--- a/src/chips/opna.cpp
+++ b/src/chips/opna.cpp
@@ -1,5 +1,6 @@
 #include "opna.hpp"
 #include <cstdint>
+#include <cstdio>
 #include <algorithm>
 #include "chip_misc.h"
 #include "mame/mame_2608.hpp"


### PR DESCRIPTION
Thank you for this project! This PR makes it possible to build the project using QT6. QT5 also still works; I tested compiling and running using both QT5 and QT6 on my system (Fedora 42) with this change, and both work fine for me.