### PR TITLE
Fix converting tone to text under QT6

### DIFF
--- a/src/tonetextdialog.cpp
+++ b/src/tonetextdialog.cpp
@@ -24,7 +24,8 @@ ToneTextDialog::~ToneTextDialog()
 	delete ui;
 }
 
-void ToneTextDialog::on_comboBox_currentIndexChanged(const QString &arg1)
+void ToneTextDialog::on_comboBox_currentIndexChanged(int index)
 {
-	ui->textEdit->setText(converter_.toneToText(tone_, arg1));
+	QString text = ui->comboBox->itemText(index);
+	ui->textEdit->setText(converter_.toneToText(tone_, text));
 }

--- a/src/tonetextdialog.h
+++ b/src/tonetextdialog.h
@@ -18,7 +18,7 @@ public:
     ~ToneTextDialog();
 
 private slots:
-	void on_comboBox_currentIndexChanged(const QString &arg1);
+	void on_comboBox_currentIndexChanged(int index);
 
 private:
     Ui::ToneTextDialog *ui;


### PR DESCRIPTION
Small follow-up to #29 for an issue I noticed earlier today preventing the "convert to text" feature from working properly under QT6. The overload of the `currentIndexChanged` signal using `const QString&` was removed in QT6, but apparently this only caused an error at runtime when the functionality was used. This alternative is [also recommended for QT5](https://doc.qt.io/qt-5/qcombobox-obsolete.html#currentIndexChanged-1), where the `const QString&` overload was marked obsolete.